### PR TITLE
fix(poolRequest): avoid setting timeout out of user req

### DIFF
--- a/lib/PoolRequest.js
+++ b/lib/PoolRequest.js
@@ -18,7 +18,7 @@ class PoolRequest {
     this.created = Date.now();
     this.callback = callback;
     this.pool = pool;
-    if (pool.options.acquireTimeoutMillis) {
+    if (callback && pool.options.acquireTimeoutMillis) {
       this.timeoutHandle = setTimeout(() => {
         this.timedOut = true;
         this.cancel();


### PR DESCRIPTION
When `new PoolRequest()` is called as part of the `_ensureMin` there is no callback, hence when timeout occurs the app will crash as callback would be undefined