### PR TITLE
[PoolRequest] make callback optional

### DIFF
--- a/lib/PoolRequest.js
+++ b/lib/PoolRequest.js
@@ -7,6 +7,8 @@
  */
 'use strict';
 
+function noop() {}
+
 class PoolRequest {
 
   /**
@@ -15,6 +17,7 @@ class PoolRequest {
    * @constructor
    */
   constructor(pool, callback) {
+    callback = callback || noop;
     this.created = Date.now();
     this.callback = callback;
     this.pool = pool;


### PR DESCRIPTION
`Pool._ensureMin` does not provide a callback to the PoolRequest
constructor. This causes an uncaught exception to be thrown by nodejs.